### PR TITLE
Add support of 'custom_kernel_specs' parameters

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1426,10 +1426,10 @@ class ServerApp(JupyterApp):
                         """,
     )
 
-    parameterized_kernels = Bool(
+    allow_insecure_kernelspec_params = Bool(
         False,
         config=True,
-        help="""Allows to switch to Parameterized kernel mode""",
+        help="""Allow to use insecure kernelspec parameters""",
     )
 
 
@@ -3034,8 +3034,10 @@ class ServerApp(JupyterApp):
         # Handle the browser opening.
         if self.open_browser and not self.sock:
             self.launch_browser()
-        if self.parameterized_kernels:
-            self.kernel_spec_manager.allow_parameterized_kernels(True)
+        if self.allow_insecure_kernelspec_params:
+            print('yesssssssssssssssss')
+            print(self.allow_insecure_kernelspec_params)
+            self.kernel_spec_manager.allow_insecure_kernelspec_params(self.allow_insecure_kernelspec_params)
 
         if self.identity_provider.token and self.identity_provider.token_generated:
             # log full URL with generated token, so there's a copy/pasteable link

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3033,9 +3033,11 @@ class ServerApp(JupyterApp):
         if self.open_browser and not self.sock:
             self.launch_browser()
         if self.allow_insecure_kernelspec_params:
-            print('yesssssssssssssssss')
+            print("yesssssssssssssssss")
             print(self.allow_insecure_kernelspec_params)
-            self.kernel_spec_manager.allow_insecure_kernelspec_params(self.allow_insecure_kernelspec_params)
+            self.kernel_spec_manager.allow_insecure_kernelspec_params(
+                self.allow_insecure_kernelspec_params
+            )
 
         if self.identity_provider.token and self.identity_provider.token_generated:
             # log full URL with generated token, so there's a copy/pasteable link

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3000,7 +3000,6 @@ class ServerApp(JupyterApp):
     def start_app(self) -> None:
         """Start the Jupyter Server application."""
         super().start()
-        #
         if not self.allow_root:
             # check if we are running as root, and abort if it's not allowed
             try:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -474,7 +474,7 @@ class ServerWebApplication(web.Application):
         return settings
 
     def page_config_hook(self, handler, page_config):
-        page_config["allow_insecure_kernelspec_params"] = self.allow_insecure_kernelspec_params 
+        page_config["allow_insecure_kernelspec_params"] = self.allow_insecure_kernelspec_params
         return page_config
 
     def init_handlers(self, default_services, settings):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -401,6 +401,8 @@ class ServerWebApplication(web.Application):
             # collapse $HOME to ~
             root_dir = "~" + root_dir[len(home) :]
 
+        self.allow_insecure_kernelspec_params = jupyter_app.allow_insecure_kernelspec_params
+
         settings = {
             # basics
             "log_function": log_request,
@@ -460,6 +462,7 @@ class ServerWebApplication(web.Application):
             "server_root_dir": root_dir,
             "jinja2_env": env,
             "serverapp": jupyter_app,
+            "page_config_hook": (self.page_config_hook),
         }
 
         # allow custom overrides for the tornado web app.
@@ -469,6 +472,10 @@ class ServerWebApplication(web.Application):
             # default: set xsrf cookie on base_url
             settings["xsrf_cookie_kwargs"] = {"path": base_url}
         return settings
+
+    def page_config_hook(self, handler, page_config):
+        page_config["allow_insecure_kernelspec_params "] = self.allow_insecure_kernelspec_params 
+        return page_config
 
     def init_handlers(self, default_services, settings):
         """Load the (URL pattern, handler) tuples for each component."""

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3040,8 +3040,6 @@ class ServerApp(JupyterApp):
         if self.open_browser and not self.sock:
             self.launch_browser()
         if self.allow_insecure_kernelspec_params:
-            print("yesssssssssssssssss")
-            print(self.allow_insecure_kernelspec_params)
             self.kernel_spec_manager.allow_insecure_kernelspec_params(
                 self.allow_insecure_kernelspec_params
             )

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1432,7 +1432,6 @@ class ServerApp(JupyterApp):
         help="""Allows to switch to Parameterized kernel mode""",
     )
 
-
     browser = Unicode(
         "",
         config=True,
@@ -2186,7 +2185,6 @@ class ServerApp(JupyterApp):
             self.event_logger.register_event_schema(schema_path)
 
     def init_webapp(self) -> None:
-        
         #
         """initialize tornado webapp"""
         self.tornado_settings["allow_origin"] = self.allow_origin
@@ -2995,7 +2993,7 @@ class ServerApp(JupyterApp):
     def start_app(self) -> None:
         """Start the Jupyter Server application."""
         super().start()
-#
+        #
         if not self.allow_root:
             # check if we are running as root, and abort if it's not allowed
             try:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1426,6 +1426,13 @@ class ServerApp(JupyterApp):
                         """,
     )
 
+    parameterized_kernels = Bool(
+        False,
+        config=True,
+        help="""Allows to switch to Parameterized kernel mode""",
+    )
+
+
     browser = Unicode(
         "",
         config=True,
@@ -2179,6 +2186,8 @@ class ServerApp(JupyterApp):
             self.event_logger.register_event_schema(schema_path)
 
     def init_webapp(self) -> None:
+        
+        #
         """initialize tornado webapp"""
         self.tornado_settings["allow_origin"] = self.allow_origin
         self.tornado_settings["websocket_compression_options"] = self.websocket_compression_options
@@ -2986,7 +2995,7 @@ class ServerApp(JupyterApp):
     def start_app(self) -> None:
         """Start the Jupyter Server application."""
         super().start()
-
+#
         if not self.allow_root:
             # check if we are running as root, and abort if it's not allowed
             try:
@@ -3025,6 +3034,8 @@ class ServerApp(JupyterApp):
         # Handle the browser opening.
         if self.open_browser and not self.sock:
             self.launch_browser()
+        if self.parameterized_kernels:
+            self.kernel_spec_manager.allow_parameterized_kernels(True)
 
         if self.identity_provider.token and self.identity_provider.token_generated:
             # log full URL with generated token, so there's a copy/pasteable link

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -474,7 +474,7 @@ class ServerWebApplication(web.Application):
         return settings
 
     def page_config_hook(self, handler, page_config):
-        page_config["allow_insecure_kernelspec_params "] = self.allow_insecure_kernelspec_params 
+        page_config["allow_insecure_kernelspec_params "] = self.allow_insecure_kernelspec_params
         return page_config
 
     def init_handlers(self, default_services, settings):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -401,8 +401,6 @@ class ServerWebApplication(web.Application):
             # collapse $HOME to ~
             root_dir = "~" + root_dir[len(home) :]
 
-        self.allow_insecure_kernelspec_params = jupyter_app.allow_insecure_kernelspec_params
-
         settings = {
             # basics
             "log_function": log_request,
@@ -462,7 +460,6 @@ class ServerWebApplication(web.Application):
             "server_root_dir": root_dir,
             "jinja2_env": env,
             "serverapp": jupyter_app,
-            "page_config_hook": (self.page_config_hook),
         }
 
         # allow custom overrides for the tornado web app.
@@ -472,10 +469,6 @@ class ServerWebApplication(web.Application):
             # default: set xsrf cookie on base_url
             settings["xsrf_cookie_kwargs"] = {"path": base_url}
         return settings
-
-    def page_config_hook(self, handler, page_config):
-        page_config["allow_insecure_kernelspec_params"] = self.allow_insecure_kernelspec_params
-        return page_config
 
     def init_handlers(self, default_services, settings):
         """Load the (URL pattern, handler) tuples for each component."""

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -474,7 +474,7 @@ class ServerWebApplication(web.Application):
         return settings
 
     def page_config_hook(self, handler, page_config):
-        page_config["allow_insecure_kernelspec_params "] = self.allow_insecure_kernelspec_params 
+        page_config["allow_insecure_kernelspec_params"] = self.allow_insecure_kernelspec_params 
         return page_config
 
     def init_handlers(self, default_services, settings):

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -94,7 +94,7 @@ class SessionRootHandler(SessionsAPIHandler):
                     kernel_id=kernel_id,
                     name=name,
                     type=mtype,
-                    custom_kernel_specs=custom_kernel_specs
+                    custom_kernel_specs=custom_kernel_specs,
                 )
             except NoSuchKernel:
                 msg = (
@@ -156,7 +156,7 @@ class SessionHandler(SessionsAPIHandler):
             changes["type"] = model["type"]
         if "custom_kernel_specs" in model:
             changes["custom_kernel_specs"] = model["custom_kernel_specs"]
-        
+
         if "kernel" in model:
             # Kernel id takes precedence over name.
             if model["kernel"].get("id") is not None:
@@ -176,7 +176,7 @@ class SessionHandler(SessionsAPIHandler):
                     name=before["name"],
                     path=before["path"],
                     type=before["type"],
-                    custom_kernel_specs = custom_kernel_specs
+                    custom_kernel_specs=custom_kernel_specs,
                 )
                 changes["kernel_id"] = kernel_id
 

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -77,6 +77,7 @@ class SessionRootHandler(SessionsAPIHandler):
         kernel = model.get("kernel", {})
         kernel_name = kernel.get("name", None)
         kernel_id = kernel.get("id", None)
+        custom_kernel_specs = kernel.get("custom_kernel_specs", {})
 
         if not kernel_id and not kernel_name:
             self.log.debug("No kernel specified, using default kernel")
@@ -93,6 +94,7 @@ class SessionRootHandler(SessionsAPIHandler):
                     kernel_id=kernel_id,
                     name=name,
                     type=mtype,
+                    custom_kernel_specs=custom_kernel_specs
                 )
             except NoSuchKernel:
                 msg = (
@@ -152,6 +154,9 @@ class SessionHandler(SessionsAPIHandler):
             changes["name"] = model["name"]
         if "type" in model:
             changes["type"] = model["type"]
+        if "custom_kernel_specs" in model:
+            changes["custom_kernel_specs"] = model["custom_kernel_specs"]
+        
         if "kernel" in model:
             # Kernel id takes precedence over name.
             if model["kernel"].get("id") is not None:
@@ -160,6 +165,10 @@ class SessionHandler(SessionsAPIHandler):
                     raise web.HTTPError(400, "No such kernel: %s" % kernel_id)
                 changes["kernel_id"] = kernel_id
             elif model["kernel"].get("name") is not None:
+                if "custom_kernel_specs" in model["kernel"]:
+                    custom_kernel_specs = model["kernel"]["custom_kernel_specs"]
+                else:
+                    custom_kernel_specs = None
                 kernel_name = model["kernel"]["name"]
                 kernel_id = await sm.start_kernel_for_session(
                     session_id,
@@ -167,6 +176,7 @@ class SessionHandler(SessionsAPIHandler):
                     name=before["name"],
                     path=before["path"],
                     type=before["type"],
+                    custom_kernel_specs = custom_kernel_specs
                 )
                 changes["kernel_id"] = kernel_id
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -267,7 +267,7 @@ class SessionManager(LoggingConfigurable):
         type: Optional[str] = None,
         kernel_name: Optional[KernelName] = None,
         kernel_id: Optional[str] = None,
-        custom_kernel_specs: Optional[Dict[str, Any]] = None
+        custom_kernel_specs: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Creates a session and returns its model
 
@@ -322,7 +322,7 @@ class SessionManager(LoggingConfigurable):
         name: Optional[ModelName],
         type: Optional[str],
         kernel_name: Optional[KernelName],
-        custom_kernel_specs: Optional[Dict[str, Any]] = None
+        custom_kernel_specs: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Start a new kernel for a given session.
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -267,6 +267,7 @@ class SessionManager(LoggingConfigurable):
         type: Optional[str] = None,
         kernel_name: Optional[KernelName] = None,
         kernel_id: Optional[str] = None,
+        custom_kernel_specs: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Creates a session and returns its model
 
@@ -282,8 +283,9 @@ class SessionManager(LoggingConfigurable):
         if kernel_id is not None and kernel_id in self.kernel_manager:
             pass
         else:
+            #
             kernel_id = await self.start_kernel_for_session(
-                session_id, path, name, type, kernel_name
+                session_id, path, name, type, kernel_name, custom_kernel_specs
             )
         record.kernel_id = kernel_id
         self._pending_sessions.update(record)
@@ -306,6 +308,7 @@ class SessionManager(LoggingConfigurable):
             Here the name is likely to be the name of the associated file
             with the current kernel at startup time.
         """
+        #
         if name is not None:
             cwd = self.kernel_manager.cwd_for_path(path)
             path = os.path.join(cwd, name)
@@ -319,6 +322,7 @@ class SessionManager(LoggingConfigurable):
         name: Optional[ModelName],
         type: Optional[str],
         kernel_name: Optional[KernelName],
+        custom_kernel_specs: Optional[Dict[str, Any]] = None
     ) -> str:
         """Start a new kernel for a given session.
 
@@ -335,6 +339,8 @@ class SessionManager(LoggingConfigurable):
             the type of the session
         kernel_name : str
             the name of the kernel specification to use.  The default kernel name will be used if not provided.
+        custom_kernel_specs: dict
+            dictionary of kernek custom specifications
         """
         # allow contents manager to specify kernels cwd
         kernel_path = await ensure_async(self.contents_manager.get_kernel_path(path=path))
@@ -344,6 +350,7 @@ class SessionManager(LoggingConfigurable):
             path=kernel_path,
             kernel_name=kernel_name,
             env=kernel_env,
+            custom_kernel_specs=custom_kernel_specs,
         )
         return cast(str, kernel_id)
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -283,7 +283,6 @@ class SessionManager(LoggingConfigurable):
         if kernel_id is not None and kernel_id in self.kernel_manager:
             pass
         else:
-            #
             kernel_id = await self.start_kernel_for_session(
                 session_id, path, name, type, kernel_name, custom_kernel_specs
             )
@@ -308,7 +307,6 @@ class SessionManager(LoggingConfigurable):
             Here the name is likely to be the name of the associated file
             with the current kernel at startup time.
         """
-        #
         if name is not None:
             cwd = self.kernel_manager.cwd_for_path(path)
             path = os.path.join(cwd, name)

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -340,7 +340,7 @@ class SessionManager(LoggingConfigurable):
         kernel_name : str
             the name of the kernel specification to use.  The default kernel name will be used if not provided.
         custom_kernel_specs: dict
-            dictionary of kernek custom specifications
+            dictionary of kernel custom specifications
         """
         # allow contents manager to specify kernels cwd
         kernel_path = await ensure_async(self.contents_manager.get_kernel_path(path=path))

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -267,7 +267,7 @@ class SessionManager(LoggingConfigurable):
         type: str | None = None,
         kernel_name: KernelName | None = None,
         kernel_id: str | None = None,
-        custom_kernel_specs: Optional[Dict[str, Any]] = None,
+        custom_kernel_specs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Creates a session and returns its model
 
@@ -318,7 +318,7 @@ class SessionManager(LoggingConfigurable):
         name: ModelName | None,
         type: str | None,
         kernel_name: KernelName | None,
-        custom_kernel_specs: Optional[Dict[str, Any]] = None,
+        custom_kernel_specs: dict[str, Any] | None = None,
     ) -> str:
         """Start a new kernel for a given session.
 


### PR DESCRIPTION
## References

This work is in progress as JEP https://github.com/jupyter/enhancement-proposals/pull/87

## Code changes
 - This PR includes support of `custom_kernel_specs` variable that is used to setup custom kernel specs before running a kernel. This `custom_kernel_specs` includes kernel parameters which a user has a selected from a kernel dialog on JupyterLab


